### PR TITLE
🔧 update (container): override release-platforms

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -34,6 +34,7 @@ jobs:
           dockerfile: ./Dockerfile
           context: .
           platforms: linux/amd64,linux/arm64
+          release-platforms: linux/amd64
 
           # Build Arguments
           build-args: |


### PR DESCRIPTION
This pull request introduces a minor update to the container build workflow by specifying a `release-platforms` value for the build step. This addition helps clarify which platform should be targeted for release builds, improving build configuration clarity.

* Added `release-platforms: linux/amd64` to the Docker build step in `.github/workflows/container.yml`.