### PR TITLE
🔒 security: fix Docker Scout vulnerabilities by updating Node.js

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.13
           
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -71,7 +71,7 @@ jobs:
           
           # Build Arguments
           build-args: |
-            NODE_VERSION=22.21-alpine3.23
+            NODE_VERSION=22.22-alpine3.23
             RAILWAY_SERVICE_ID=${{ secrets.RAILWAY_SERVICE_ID }}
           
           # Labels

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -38,7 +38,7 @@ jobs:
 
           # Build Arguments
           build-args: |
-            NODE_VERSION=22.21-alpine3.23
+            NODE_VERSION=22.22-alpine3.23
             RAILWAY_SERVICE_ID=${{ secrets.RAILWAY_SERVICE_ID }}
 
           # Labels

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.13
           
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,11 @@
 
 # syntax=docker/dockerfile:1
 
-# Use Node.js 22.21 LTS Alpine with security patches
-ARG NODE_VERSION=22.21-alpine3.23
+# Use Node.js 22.22 LTS Alpine with security patches
+ARG NODE_VERSION=22.22-alpine3.23
+
+# Bun version used in build stages (must match packageManager in package.json)
+ARG BUN_VERSION=1.3.13
 
 # Get Railway service ID for cache mounts
 ARG RAILWAY_SERVICE_ID
@@ -27,7 +30,7 @@ ARG RAILWAY_SERVICE_ID
 # =============================================================================
 # STAGE 1: Base Image
 # =============================================================================
-# Alpine Linux 3.21 base for minimal image size with latest security updates
+# Alpine Linux 3.23 base for minimal image size with latest security updates
 FROM node:${NODE_VERSION} AS base
 
 # Install security updates for Alpine packages
@@ -45,9 +48,11 @@ WORKDIR /usr/src/app
 # image, keeping the production image smaller and reducing attack surface.
 FROM base AS bun-base
 
+# Re-declare ARG so the global value is accessible in this stage
+ARG BUN_VERSION
+
 # Install Bun for dependency management
-# Note: Version must match packageManager field in package.json (currently 1.3.11)
-RUN npm install --global bun@1.3.11
+RUN npm install --global bun@${BUN_VERSION}
 
 # =============================================================================
 # STAGE 2: Production Dependencies
@@ -78,6 +83,10 @@ RUN --mount=type=bind,source=package.json,target=package.json \
 COPY . .
 RUN bun run build
 
+# Create a production-only package.json (strip devDependencies so Docker Scout
+# does not flag transitive dev-only packages like picomatch@^2.x from nodemon)
+RUN node -e "const p=require('./package.json');delete p.devDependencies;process.stdout.write(JSON.stringify(p,null,2));" > /tmp/package-prod.json
+
 # =============================================================================
 # STAGE 4: Final Runtime Image
 # =============================================================================
@@ -92,8 +101,9 @@ ENV NODE_ENV=production \
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001 -G nodejs
 
-# Copy package.json for package manager commands
-COPY --chown=nodejs:nodejs package.json .
+# Copy production-only package.json (no devDependencies) to avoid Docker Scout
+# false-positives from dev dep chains that reference picomatch@^2.x
+COPY --from=build --chown=nodejs:nodejs /tmp/package-prod.json ./package.json
 
 # Copy production dependencies and built application
 COPY --from=deps --chown=nodejs:nodejs /usr/src/app/node_modules ./node_modules

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "dist/app.js",
   "engines": {
     "node": ">=22.0.0",
-    "bun": "1.3.11"
+    "bun": "1.3.13"
   },
   "scripts": {
     "build": "tsc",
@@ -65,5 +65,5 @@
     "flatted": "3.4.2",
     "picomatch": "4.0.4"
   },
-  "packageManager": "bun@1.3.11"
+  "packageManager": "bun@1.3.13"
 }


### PR DESCRIPTION
This pull request updates the project's Node.js and Bun versions across the Dockerfile, GitHub Actions workflows, and `package.json` to keep dependencies current and improve security. It also introduces a Docker build improvement to strip devDependencies from the production image, reducing false positives in security scans.

**Dependency version updates:**

* Updated Node.js version from `22.21-alpine3.23` to `22.22-alpine3.23` in `Dockerfile`, `.github/workflows/build.yml`, and `.github/workflows/container.yml` to ensure the latest security patches and features. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L21-R33) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L74-R74) [[3]](diffhunk://#diff-87249919b62f3d7f70416176a4254d5df6e59eab47c6de2a2a4fbbcf4138cbacL41-R41)
* Updated Bun version from `1.3.11` to `1.3.13` in `Dockerfile`, `.github/workflows/build.yml`, `.github/workflows/validate.yml`, and `package.json` for consistency across environments. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R51-R55) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L21-R21) [[3]](diffhunk://#diff-a5c0f08bc43f53a0451cad4a4a2e435ce55ad34183350dfae5e4b2c7dca6360bL19-R19) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L24-R24) [[5]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L68-R68)

**Docker build and production image improvements:**

* Added a build step to generate a production-only `package.json` (without `devDependencies`) and copy it into the final Docker image, reducing false positives in vulnerability scans from dev-only packages. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R86-R89) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L95-R106)